### PR TITLE
Replace colon to dash

### DIFF
--- a/crawler/index.js
+++ b/crawler/index.js
@@ -79,7 +79,7 @@ class Crawler {
   }
 
   async writePost(post) {
-    const path = join('backup', 'content', `${post.title.replace(/\//g, ' ')}.md`);
+    const path = join('backup', 'content', `${post.title.replace(/\//g, ' ').replace(':','-')}.md`);
 
     post.body = '---\n'
                 + `title: "${post.title}"\n`


### PR DESCRIPTION
Fixed an issue that could not be saved properly if the title included colon.

**example case**
velog post : [[assembly: InternalsVisibleTo(string)]](https://velog.io/@1111/assembly-InternalsVisibleTostring)