### PR TITLE
Hotfix/write file promise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+backup/

--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ program.parse(process.argv);
 !fs.existsSync('./backup/images') && fs.mkdirSync('./backup/images');
 
 const crawler = new Crawler(program.username, { 
-  delay: program.delay || 0,
+  delay: program.delay || 100,
   cert: program.cert,
 });
 

--- a/crawler/index.js
+++ b/crawler/index.js
@@ -111,8 +111,19 @@ class Crawler {
                 + `date: ${post.released_at}\n`
                 + `tags: ${JSON.stringify(post.tags)}\n`
                 + '---\n' + post.body;
-                
-    await fs.promises.writeFile(path, post.body, 'utf8');
+    const wf = (path, body) => {
+      return new Promise((resolve, reject) => {
+        fs.writeFile(path, body, 'utf8', (err) => {
+          if (err != undefined) {
+            reject(err);
+          }
+          else {
+            resolve();
+          }
+        });
+      }).catch((err) => console.log('error occured: ', err));
+    };     
+    wf(path, post.body);      
   }
 
   async getImage(body) {


### PR DESCRIPTION
안녕하세요. velog backup 사용 중에 아래와 같은 에러가 발생해서 해당 사항을 수정했습니다.  

System Specification
- Ubuntu 20.04
- Node.js 8.10.0

```sh
(node:5115) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'writeFile' of undefined
    at Crawler.writePost (/home/ubuntu/git/velog-backup/crawler/index.js:115:23)
    at posts.map (/home/ubuntu/git/velog-backup/crawler/index.js:42:18)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
(node:5115) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 438)
```
기존 promise 코드를 길게 늘려서 작성하니 해결됐습니다. 


또한 velog 작성 글이 많아질 경우, velog의 요청 처리 시간 때문에 일부 글들을 다운 받지 못하는 이슈가 있습니다. 
default delay를 100으로 설정해서 이를 해결했습니다.